### PR TITLE
remove unnecessary/confusing instruction from README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ Then, start your app with
     python service/web.py
 
 **Note the application will try to connect to the database at this point, and will try to create the database if it does not exist.**
-
-If you want to specify your own root config file, you can use
-
-    APP_CONFIG=path/to/rootcfg.py python service/web.py
     
 ## Configuration
 


### PR DESCRIPTION
Once the app runs, installation is over. This is stuff leftover from the app-template repo which I was customising to get this app up.
