### PR TITLE
add server_costs table

### DIFF
--- a/migrations/versions/1e27c434bb14_create_server_costs.py
+++ b/migrations/versions/1e27c434bb14_create_server_costs.py
@@ -1,0 +1,28 @@
+"""create server_costs table
+
+Revision ID: 1e27c434bb14
+Revises: fa0f07475596
+Create Date: 2016-03-14 15:57:19.945327
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1e27c434bb14'
+down_revision = 'fa0f07475596'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.create_table(
+        'server_costs',
+        sa.Column('project_url', sa.String(length=255), sa.ForeignKey('projects.url'), nullable=False, primary_key=True),
+        sa.Column('value', sa.Numeric(precision=10, scale=2), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_table('server_costs')


### PR DESCRIPTION
This is the final table present in pull-openbooks-into-postgres.py .

I have taken the liberty of modifying the table slightly to make sure we can actually manage this on the web front-end more easily - it requires the project URL instead of name now, and is foreign-keyed to projects. That means that the incoming data will of course need to have the URL, but this is a fine requirement to have - all that's needed is that we take the name from each record in the CSV, and look up the URL. If one does not match, we have a problem and the CSV data needs manual adjustment (which is a good thing to know/do).
