### PR TITLE
add some flask extensions to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "sqlalchemy-utils==0.31.4",
         "Flask-OAuthlib==0.9.2",
         "Flask-Script==2.0.5",
+        "Flask-Alembic==1.2.1",
         "oauth2client==2.0.1",
         # for deployment
         "gunicorn",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "Flask-Migrate==1.6.0",
         "sqlalchemy-utils==0.31.4",
         "Flask-OAuthlib==0.9.2",
+        "Flask-Script==2.0.5",
         "oauth2client==2.0.1",
         # for deployment
         "gunicorn",


### PR DESCRIPTION
I was running experiments to see if we would like using Flask-Script and Flask-Alembic and I forgot to include them in the requirements file.

Still not so sure about Flask-Script but it works well with Alembic, which in turn seems to work very well for managing migrations, so in they go.
